### PR TITLE
Fix imports in profanity filter

### DIFF
--- a/constraint_lattice/constraints/profanity.py
+++ b/constraint_lattice/constraints/profanity.py
@@ -2,6 +2,10 @@
 # Copyright (c) 2025 ochoaughini. All rights reserved.
 # See LICENSE for full terms.
 
+from typing import List, Optional
+import re
+
+
 class ProfanityFilter:
     """Filter for detecting and replacing profanity in text.
     


### PR DESCRIPTION
## Summary
- add missing imports to `ProfanityFilter` implementation
- keep only `main` branch locally

## Testing
- `pytest -q` *(fails: pyenv: version `3.12.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686a9fc72cb0832f864e8e641f0b058b