### PR TITLE
Add meta orchestrator pipeline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22,6 +22,10 @@ import sys
 from pathlib import Path
 
 from sdk.engine import ConstraintEngine
+from constraint_lattice.engine import (
+    ConstraintLatticePipeline,
+    recursive_autolearning_orchestrator,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -41,6 +45,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Emit full JSON with audit trace (default: text only)",
     )
+    p.add_argument(
+        "--enable-meta-strategy",
+        action="store_true",
+        help="Invoke meta orchestrator after constraint evaluation",
+    )
     return p.parse_args()
 
 
@@ -52,7 +61,19 @@ def main() -> None:
     # Naive inference stub – real model call intentionally omitted for brevity.
     # Replace with transformers pipeline or server call as needed.
     generated = f"[MODEL:{args.model}] response for: {args.prompt}"
-    moderated, trace = engine.run(args.prompt, generated, return_trace=True)
+
+    if args.enable_meta_strategy:
+        pipeline = ConstraintLatticePipeline(
+            engine.constraints,
+            meta_orchestrator=recursive_autolearning_orchestrator,
+        )
+        moderated, trace = pipeline.run(
+            args.prompt,
+            generated,
+            return_trace=True,
+        )
+    else:
+        moderated, trace = engine.run(args.prompt, generated, return_trace=True)
 
     if args.json:
         print(json.dumps({"moderated": moderated, "trace": [s.to_dict() for s in trace]}))

--- a/src/constraint_lattice/engine/__init__.py
+++ b/src/constraint_lattice/engine/__init__.py
@@ -4,10 +4,12 @@
 from .constraint import Constraint
 from .apply import apply_constraints
 from .autolearning import apply_containment_constraints, recursive_autolearning_orchestrator
+from .pipeline import ConstraintLatticePipeline
 
 __all__ = [
     "Constraint",
     "apply_constraints",
     "apply_containment_constraints",
     "recursive_autolearning_orchestrator",
+    "ConstraintLatticePipeline",
 ]

--- a/src/constraint_lattice/engine/apply.py
+++ b/src/constraint_lattice/engine/apply.py
@@ -62,6 +62,8 @@ class AuditStep:
     timestamp: datetime = field(
         default_factory=lambda: datetime.utcnow().replace(tzinfo=timezone.utc)
     )
+    strategy_reindex: Optional[Dict[str, Any]] = None
+    drift_score: Optional[float] = None
 
     # Lifecycle and core methods
     def to_dict(self):
@@ -83,6 +85,10 @@ class AuditStep:
             base["model_scores"] = self.model_scores
         if self.embeddings:
             base["embeddings"] = self.embeddings
+        if self.strategy_reindex is not None:
+            base["strategy_reindex"] = self.strategy_reindex
+        if self.drift_score is not None:
+            base["drift_score"] = self.drift_score
         return base
 
 

--- a/src/constraint_lattice/engine/loader.py
+++ b/src/constraint_lattice/engine/loader.py
@@ -2,6 +2,14 @@
 # Copyright (c) 2025 ochoaughini. All rights reserved.
 # See LICENSE for full terms.
 
+import importlib
+import json
+import os
+import hashlib
+from typing import List, Type
+
+import yaml  # type: ignore
+
 from .schema import ConstraintConfig, ConstraintSchema
 from constraint_lattice.engine import Constraint
 

--- a/src/constraint_lattice/engine/pipeline.py
+++ b/src/constraint_lattice/engine/pipeline.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+"""Simple orchestration pipeline for applying constraints then optional meta logic."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Callable, Iterable, Tuple, Any, Dict, Optional
+
+from .apply import apply_constraints, AuditTrace, AuditStep
+
+
+class ConstraintLatticePipeline:
+    """Run constraints and then an optional meta orchestrator."""
+
+    def __init__(self, constraints: Iterable[Any], *, meta_orchestrator: Optional[Callable[..., Dict[str, Any]]] = None) -> None:
+        self.constraints = list(constraints)
+        self.meta_orchestrator = meta_orchestrator
+
+    def run(
+        self,
+        prompt: str,
+        output: str,
+        *,
+        return_trace: bool = False,
+        **kwargs: Any,
+    ) -> Tuple[str, AuditTrace] | str:
+        """Apply constraints then invoke ``meta_orchestrator`` if provided."""
+        result = apply_constraints(prompt, output, self.constraints, return_audit_trace=return_trace)
+
+        if return_trace:
+            moderated, trace = result
+        else:
+            moderated = result
+            trace = AuditTrace()
+
+        if self.meta_orchestrator:
+            meta = self.meta_orchestrator(moderated, trace, **kwargs)
+            if isinstance(meta, dict):
+                step = AuditStep(
+                    constraint="meta_orchestrator",
+                    method=self.meta_orchestrator.__name__,
+                    pre_text=moderated,
+                    post_text=moderated,
+                    elapsed_ms=0.0,
+                    timestamp=datetime.now(timezone.utc),
+                )
+                step.strategy_reindex = meta.get("strategy_reindex")
+                step.drift_score = meta.get("drift_score")
+                trace.append(step)
+
+        return (moderated, trace) if return_trace else moderated


### PR DESCRIPTION
## Summary
- add `ConstraintLatticePipeline` to allow custom post-processing orchestrator callbacks
- export pipeline in engine package
- extend `AuditStep` JSONL schema to include optional `strategy_reindex` and `drift_score`
- register orchestrator via `--enable-meta-strategy` flag in CLI
- fix imports in loader for type hints

## Testing
- `pytest -q` *(fails: missing packages / syntax errors)*

------
https://chatgpt.com/codex/tasks/task_b_686c03285f0c832f9c906f916a216066