### PR TITLE
Implement lightweight cognitive components

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Constraint Lattice enables **composable constraints** that rewrite, redact, or r
 - **Deterministic Execution**: JSONL audit logs for governance and compliance
 - **GPU Acceleration**: Optional vLLM/JAX backend for high-performance moderation
 - **Production Ready**: Prometheus metrics and Stripe billing integration
+- **Cognitive Components**: optional package `cognitive_arch` providing hierarchical memory, metacognitive logging, agent governance and adaptive ethics utilities
 
 ## Architecture
 

--- a/src/cognitive_arch/__init__.py
+++ b/src/cognitive_arch/__init__.py
@@ -1,0 +1,16 @@
+"""Lightweight cognitive architecture components."""
+
+from .hierarchical_memory import HierarchicalMemory
+from .metacognitive_scaffold import MetaConstraintLog, ConstraintEvent
+from .agent_governance import Agent, GovernanceCoordinator
+from .multimodal_ethics import AdaptiveEthics, EthicalRule
+
+__all__ = [
+    "HierarchicalMemory",
+    "MetaConstraintLog",
+    "ConstraintEvent",
+    "Agent",
+    "GovernanceCoordinator",
+    "AdaptiveEthics",
+    "EthicalRule",
+]

--- a/src/cognitive_arch/agent_governance.py
+++ b/src/cognitive_arch/agent_governance.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List
+
+
+@dataclass
+class Agent:
+    name: str
+    act: Callable[[str], str]
+
+
+@dataclass
+class GovernanceCoordinator:
+    agents: List[Agent] = field(default_factory=list)
+
+    def register(self, agent: Agent) -> None:
+        self.agents.append(agent)
+
+    def broadcast(self, message: str) -> Dict[str, str]:
+        """Send the same message to all agents and collect their responses."""
+        return {agent.name: agent.act(message) for agent in self.agents}
+
+    def consensus(self, message: str) -> str:
+        """Return the response that most agents agree on."""
+        responses = self.broadcast(message)
+        vote_count: Dict[str, int] = {}
+        for resp in responses.values():
+            vote_count[resp] = vote_count.get(resp, 0) + 1
+        return max(vote_count, key=vote_count.get)

--- a/src/cognitive_arch/hierarchical_memory.py
+++ b/src/cognitive_arch/hierarchical_memory.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+class HierarchicalMemory:
+    """Simple persistent hierarchical memory.
+
+    Stores nested symbolic data structures to simulate a distributed memory.
+    Data is persisted to a JSON file so it can be reloaded across sessions.
+    This is a lightweight stand-in for the advanced memory described in the
+    research notes.
+    """
+
+    def __init__(self, path: str | Path = "memory.json") -> None:
+        self.path = Path(path)
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as fh:
+                self._data: Dict[str, Any] = json.load(fh)
+        else:
+            self._data = {}
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump(self._data, fh, indent=2)
+
+    def add(self, keys: List[str], value: Any) -> None:
+        """Add a value under a hierarchy of keys."""
+        node = self._data
+        for key in keys[:-1]:
+            node = node.setdefault(key, {})
+        node[keys[-1]] = value
+        self._save()
+
+    def get(self, keys: List[str]) -> Any:
+        node = self._data
+        for key in keys:
+            node = node.get(key, {})
+        return node
+
+    def search(self, key: str) -> List[Any]:
+        """Return all values associated with key anywhere in the hierarchy."""
+        results = []
+        stack = [self._data]
+        while stack:
+            current = stack.pop()
+            if isinstance(current, dict):
+                for k, v in current.items():
+                    if k == key:
+                        results.append(v)
+                    if isinstance(v, dict):
+                        stack.append(v)
+        return results

--- a/src/cognitive_arch/metacognitive_scaffold.py
+++ b/src/cognitive_arch/metacognitive_scaffold.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+@dataclass
+class ConstraintEvent:
+    constraint: str
+    before: str
+    after: str
+
+@dataclass
+class MetaConstraintLog:
+    path: Path
+    events: List[ConstraintEvent] = field(default_factory=list)
+
+    def log(self, constraint: str, before: str, after: str) -> None:
+        self.events.append(ConstraintEvent(constraint, before, after))
+        self.save()
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump([e.__dict__ for e in self.events], fh, indent=2)
+
+    def summary(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for e in self.events:
+            counts[e.constraint] = counts.get(e.constraint, 0) + 1
+        return counts

--- a/src/cognitive_arch/multimodal_ethics.py
+++ b/src/cognitive_arch/multimodal_ethics.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class EthicalRule:
+    name: str
+    forbidden_terms: List[str]
+    context: str | None = None
+
+
+class AdaptiveEthics:
+    """Very small ethical modulation engine.
+
+    Checks a text for forbidden terms depending on context and can adapt rules
+    dynamically at runtime.
+    """
+
+    def __init__(self, rules: List[EthicalRule] | None = None) -> None:
+        self.rules = rules or []
+
+    def check(self, text: str, context: str | None = None) -> List[str]:
+        violations: List[str] = []
+        for rule in self.rules:
+            if rule.context and context and rule.context != context:
+                continue
+            for term in rule.forbidden_terms:
+                if term.lower() in text.lower():
+                    violations.append(rule.name)
+                    break
+        return violations
+
+    def add_rule(self, rule: EthicalRule) -> None:
+        self.rules.append(rule)

--- a/tests/unit/test_cognitive_arch.py
+++ b/tests/unit/test_cognitive_arch.py
@@ -1,0 +1,33 @@
+from cognitive_arch import (
+    AdaptiveEthics,
+    EthicalRule,
+    HierarchicalMemory,
+    MetaConstraintLog,
+    GovernanceCoordinator,
+    Agent,
+)
+
+
+def test_hierarchical_memory(tmp_path):
+    mem = HierarchicalMemory(tmp_path / "mem.json")
+    mem.add(["session", "message"], "hello")
+    assert mem.get(["session", "message"]) == "hello"
+
+
+def test_meta_constraint_log(tmp_path):
+    log = MetaConstraintLog(path=tmp_path / "log.json")
+    log.log("rule1", "before", "after")
+    assert log.summary()["rule1"] == 1
+
+
+def test_governance_coordinator():
+    def echo(msg: str) -> str:
+        return msg
+    gov = GovernanceCoordinator()
+    gov.register(Agent("a", echo))
+    assert gov.broadcast("hi") == {"a": "hi"}
+
+
+def test_adaptive_ethics():
+    ethics = AdaptiveEthics([EthicalRule(name="no-x", forbidden_terms=["x"])])
+    assert ethics.check("contains x") == ["no-x"]


### PR DESCRIPTION
## Summary
- add cognitive architecture utilities for hierarchical memory, metacognitive logging, agent governance and ethics checking
- expose new package via `cognitive_arch`
- document these components in README
- test new functionality

## Testing
- `pytest tests/unit/test_cognitive_arch.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686c1227d19c832f923aeef8c1458ed2