### PR TITLE
Implement Cognitive Integration Loop

### DIFF
--- a/docs/cognitive_integration_loop.md
+++ b/docs/cognitive_integration_loop.md
@@ -1,0 +1,42 @@
+# Cognitive Integration Loop
+
+This design note introduces a lightweight orchestration layer that binds
+small language models with the existing Constraint Lattice tooling. The
+loop provides a symbolic registry of available models, a simple policy
+engine for routing requests, and a placeholder synthesiser for deriving
+constraints from raw documents.
+
+## Components
+
+- **ModelRegistry** – tracks `ModelWrapper` instances keyed by name.
+- **CallPolicyEngine** – chooses which model to invoke based on compute
+  hints or feedback severity.
+- **ConstraintSynthesizer** – converts incoming text into preliminary
+  constraint structures. This stub demonstrates how unstructured
+  artifacts could be transformed before being passed to
+  `apply_containment_constraints` and the
+  `recursive_autolearning_orchestrator` described in
+  [containment_autolearning.md](containment_autolearning.md).
+- **CognitiveIntegrationLoop** – coordinates model selection, processes
+  input prompts, logs results to `HierarchicalMemory`, and exposes an
+  asynchronous `heartbeat` for runtime status checks.
+
+## Usage
+
+```python
+from cognitive_arch import CognitiveIntegrationLoop
+
+loop = CognitiveIntegrationLoop()
+loop.register_model("phi-2", lambda x: "phi2:" + x)
+loop.register_model("gemma", lambda x: "gemma:" + x)
+
+result = loop.process("hello", compute="low")
+print(result)  # -> "phi2:hello"
+```
+
+This module is intentionally minimal. It demonstrates how Varkiel could
+autonomously route requests and maintain a provenance-aware trace of its
+reasoning steps.
+
+---
+Last updated: 2025-07-03

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Welcome! This page is the starting point for all user guides, design notes, and 
 
 ## Proposals
 - [Phi-2 Integration Proposal](phi2_integration_proposal.md)
+- [Cognitive Integration Loop](cognitive_integration_loop.md)
 
 ## Examples
 - [Transformers Gemma Example](transformers_gemma_example.md)

--- a/src/cognitive_arch/__init__.py
+++ b/src/cognitive_arch/__init__.py
@@ -4,6 +4,12 @@ from .hierarchical_memory import HierarchicalMemory
 from .metacognitive_scaffold import MetaConstraintLog, ConstraintEvent
 from .agent_governance import Agent, GovernanceCoordinator
 from .multimodal_ethics import AdaptiveEthics, EthicalRule
+from .integration_loop import (
+    CognitiveIntegrationLoop,
+    ModelRegistry,
+    ModelWrapper,
+    CallPolicyEngine,
+)
 
 __all__ = [
     "HierarchicalMemory",
@@ -13,4 +19,8 @@ __all__ = [
     "GovernanceCoordinator",
     "AdaptiveEthics",
     "EthicalRule",
+    "CognitiveIntegrationLoop",
+    "ModelRegistry",
+    "ModelWrapper",
+    "CallPolicyEngine",
 ]

--- a/src/cognitive_arch/integration_loop.py
+++ b/src/cognitive_arch/integration_loop.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from .hierarchical_memory import HierarchicalMemory
+
+
+class ModelWrapper:
+    """Lightweight wrapper around a callable model."""
+
+    def __init__(
+        self, name: str, call_fn: Callable[[str], str], threshold: float = 1.0
+    ) -> None:
+        self.name = name
+        self.call_fn = call_fn
+        self.threshold = threshold
+
+    def __call__(self, prompt: str) -> str:
+        return self.call_fn(prompt)
+
+
+@dataclass
+class ModelRegistry:
+    """Registry of available models."""
+
+    models: dict[str, ModelWrapper] = field(default_factory=dict)
+
+    def register(self, model: ModelWrapper) -> None:
+        self.models[model.name] = model
+
+    def get(self, name: str) -> ModelWrapper | None:
+        return self.models.get(name)
+
+
+class CallPolicyEngine:
+    """Simple policy engine to select a model based on heuristics."""
+
+    def __init__(self, registry: ModelRegistry) -> None:
+        self.registry = registry
+
+    def select(self, compute: str | None = None, severity: float = 0.0) -> ModelWrapper:
+        if compute == "low" and "phi-2" in self.registry.models:
+            return self.registry.models["phi-2"]
+        if severity > 0.5 and "gemma" in self.registry.models:
+            return self.registry.models["gemma"]
+        return next(iter(self.registry.models.values()))
+
+
+class ConstraintSynthesizer:
+    """Placeholder for converting raw text into constraint representations."""
+
+    def synthesize(self, text: str) -> dict[str, Any]:
+        return {"constraint": text[:30]}
+
+
+class CognitiveIntegrationLoop:
+    """Coordinator tying together models, policy, and memory."""
+
+    def __init__(self, memory_path: str = "memory.json") -> None:
+        self.registry = ModelRegistry()
+        self.policy = CallPolicyEngine(self.registry)
+        self.synthesizer = ConstraintSynthesizer()
+        self.memory = HierarchicalMemory(memory_path)
+
+    def register_model(self, name: str, call_fn: Callable[[str], str]) -> None:
+        self.registry.register(ModelWrapper(name, call_fn))
+
+    def process(
+        self, prompt: str, compute: str | None = None, severity: float = 0.0
+    ) -> str:
+        model = self.policy.select(compute, severity)
+        result = model(prompt)
+        self.memory.add(["trace", model.name], {"prompt": prompt, "result": result})
+        return result
+
+    async def heartbeat(self, interval: float = 60.0) -> None:
+        while True:
+            await asyncio.sleep(interval)
+            status = list(self.registry.models.keys())
+            self.memory.add(["heartbeat"], {"registered_models": status})


### PR DESCRIPTION
## Summary
- add design note for Cognitive Integration Loop
- implement `integration_loop` module under `cognitive_arch`
- expose new classes in package `__init__`
- reference the design note from the docs index

## Testing
- `ruff check src/cognitive_arch/integration_loop.py`
- `black src/cognitive_arch/integration_loop.py`
- `pytest -q` *(fails: missing transformers conversation module)*

------
https://chatgpt.com/codex/tasks/task_b_686c4bfc29c4832f9416e4038073e1be