### PR TITLE
Add Varkiel architecture overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,3 +23,5 @@ Welcome! This page is the starting point for all user guides, design notes, and 
 
 ---
 Last updated: 2025-07-03
+
+- [Varkiel Architecture Overview](varkiel_overview.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,4 @@ Welcome! This page is the starting point for all user guides, design notes, and 
 Last updated: 2025-07-03
 
 - [Varkiel Architecture Overview](varkiel_overview.md)
+- [Varkiel Scripts and Actions](varkiel_scripts.md)

--- a/docs/varkiel_overview.md
+++ b/docs/varkiel_overview.md
@@ -1,0 +1,41 @@
+# Varkiel Architecture Overview
+
+This document summarizes the Varkiel cognitive agent design as implemented in this repository. Varkiel operates in **offline** and **online** modes while enforcing a lattice of constraints to avoid hallucinations and policy violations.
+
+## Core Components
+
+- **Core Orchestrator** – entry point that coordinates reasoning steps and transitions between phases.
+- **Constraint Lattice Engine** – stores facts and rules as nodes in a lattice. All new content is validated against this structure.
+- **WildCore Detector** – anomaly detection layer used on all inputs and candidate outputs.
+- **Local Inference Cores** – lightweight models (Phi‑2 and Gemma) used for moderation and formalization when no internet is available.
+- **Foundation Model Interface** – optional proxy used in online mode to query external LLMs. Returned answers are validated before use.
+- **Semantic Memory Store** – persistent knowledge base indexed by embeddings and symbolic keys.
+- **Autonomous Learning** – background process monitoring drift and updating constraints over time.
+
+## Offline Mode
+
+When running without internet access Varkiel relies exclusively on local resources:
+
+1. Input is moderated with Phi‑2 and parsed by Gemma.
+2. Parsed knowledge is inserted as new nodes in the Constraint Lattice.
+3. Queries are answered using only stored constraints and local inference. Any draft answer must be verified by the lattice before delivery.
+4. If verification fails, Varkiel refuses or requests clarification instead of guessing.
+
+## Online Mode
+
+In online mode the orchestrator may delegate sub‑tasks to external LLMs:
+
+1. The Core formulates a focused epistemic query including relevant constraints.
+2. The Foundation Model Interface sends this prompt to one or more models (e.g. GPT‑4 or Claude).
+3. Model outputs are evaluated by the lattice and WildCore. Conflicting or unverifiable statements are rejected.
+4. Varkiel may integrate verified new knowledge into the memory store and iteratively refine the response.
+
+The constraint lattice ensures that online assistance cannot override existing policies or introduce hallucinations.
+
+## Files
+
+- `varkiel_agent_main/src/varkiel/central_controller.py` – main orchestrator implementation.
+- `varkiel_agent_main/src/varkiel/constraint_lattice_adapter.py` – interface to the constraint lattice.
+- `varkiel_agent_main/ARCHITECTURE.md` – original high‑level blueprint.
+
+This overview complements those documents with a concise explanation of offline and online operation.

--- a/docs/varkiel_scripts.md
+++ b/docs/varkiel_scripts.md
@@ -1,0 +1,51 @@
+# Varkiel Scripts and Actions
+
+This document lists the helper scripts included in the repository that are useful when working with the Varkiel architecture. Each entry briefly describes what the script does and how to invoke it.
+
+## Python Scripts
+
+### `scripts/bench_phi2.py`
+Benchmark the Phi‑2 moderation model. Example:
+
+```bash
+python scripts/bench_phi2.py --tokens 128 256 --runs 3 --device cpu
+```
+
+### `scripts/gemma_demo.py`
+Download the Gemma model and run a simple generation through the constraint pipeline.
+
+```bash
+python scripts/gemma_demo.py --prompt "Hello world" > out.txt
+```
+
+### `scripts/dual_gen_demo.py`
+Generate text using Gemma and Phi‑2 for side‑by‑side comparison. Example:
+
+```bash
+python scripts/dual_gen_demo.py --device cuda:0
+```
+
+## Shell Scripts
+
+### `scripts/start_server.sh`
+Start the FastAPI server in development mode.
+
+```bash
+bash scripts/start_server.sh
+```
+
+### `scripts/run_tests.sh`
+Run the full test suite.
+
+```bash
+bash scripts/run_tests.sh
+```
+
+### `scripts/prefetch.py`
+Download Gemma and Phi‑2 weights into the local cache.
+
+```bash
+python scripts/prefetch.py
+```
+
+These scripts provide common actions for experimenting with or deploying the Varkiel agent. See each file for additional options.


### PR DESCRIPTION
## Summary
- document Varkiel offline/online operation and core modules
- link new overview from docs index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_b_686c55192450832fbd0d43c7a8d4ae82