### PR TITLE
Add Varkiel agent skeleton

### DIFF
--- a/src/varkiel/__init__.py
+++ b/src/varkiel/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+"""Varkiel cognitive agent package."""
+
+from .agent import VarkielAgent
+
+__all__ = ["VarkielAgent"]

--- a/src/varkiel/agent.py
+++ b/src/varkiel/agent.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+"""Minimal orchestrator implementing Varkiel concepts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .constraint_lattice import ConstraintLattice
+from .wildcore import WildCore
+from .phi2_model import moderate
+from .gemma_model import extract_facts
+from .foundation_proxy import FoundationProxy
+from .memory_store import MemoryStore
+from .autolearn import DriftManager
+
+
+@dataclass
+class VarkielAgent:
+    """Lightweight demonstration agent."""
+
+    lattice: ConstraintLattice
+    wildcore: WildCore
+    foundation: FoundationProxy
+    memory: MemoryStore
+    drift: DriftManager
+
+    def ingest(self, text: str, source: str = "user") -> None:
+        if self.wildcore.scan(text):
+            return
+        text = moderate(text)
+        facts = extract_facts(text)
+        for i, fact in enumerate(facts):
+            node_id = f"{source}_{i}"
+            self.lattice.add_node(node_id, fact, source=source)
+            self.memory.add(node_id, fact)
+        self.drift.update(facts)
+
+    def query(self, prompt: str) -> str:
+        if self.wildcore.scan(prompt):
+            return "Request blocked."
+        if self.lattice.validate(prompt):
+            return prompt
+        external = self.foundation.query(prompt)
+        if external:
+            external = moderate(external)
+        if external and self.lattice.validate(external):
+            return external
+        return "I don't know."

--- a/src/varkiel/autolearn.py
+++ b/src/varkiel/autolearn.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+"""Simple drift detection stub."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+class DriftManager:
+    """Track distribution of added knowledge."""
+
+    def __init__(self) -> None:
+        self.count = 0
+
+    def update(self, items: Iterable[str]) -> None:
+        self.count += len(list(items))
+
+    def drift_score(self) -> float:
+        return float(self.count)

--- a/src/varkiel/constraint_lattice.py
+++ b/src/varkiel/constraint_lattice.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+"""Simplified constraint lattice for the Varkiel agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Iterable
+import numpy as np
+
+
+@dataclass
+class ConstraintNode:
+    """Node in the constraint lattice."""
+
+    content: str
+    embedding: np.ndarray
+    source: str = ""
+    parents: List[str] = field(default_factory=list)
+
+
+class ConstraintLattice:
+    """Basic knowledge store and validator."""
+
+    def __init__(self) -> None:
+        self.nodes: Dict[str, ConstraintNode] = {}
+
+    def add_node(self, node_id: str, content: str, *, source: str = "", parents: Iterable[str] | None = None, embedding: Iterable[float] | None = None) -> None:
+        if embedding is None:
+            embedding = np.zeros(3)
+        parents_list = list(parents) if parents else []
+        self.nodes[node_id] = ConstraintNode(content, np.array(embedding), source, parents_list)
+
+    def get(self, node_id: str) -> ConstraintNode | None:
+        return self.nodes.get(node_id)
+
+    def query(self, text: str) -> List[ConstraintNode]:
+        """Return nodes with high embedding similarity to *text* (placeholder)."""
+        # In a real system we would embed text and do nearest-neighbour search.
+        return [n for n in self.nodes.values() if n.content.lower() in text.lower()]
+
+    def validate(self, text: str) -> bool:
+        """Check that *text* does not contradict stored constraints (placeholder)."""
+        for node in self.nodes.values():
+            if node.content.lower() == text.lower():
+                return True
+        return False

--- a/src/varkiel/foundation_proxy.py
+++ b/src/varkiel/foundation_proxy.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+"""Minimal interface to external language models."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+class FoundationProxy:
+    """Return canned responses to mimic external LLMs."""
+
+    def __init__(self, responses: Iterable[str] | None = None) -> None:
+        self._responses = list(responses or [])
+
+    def query(self, prompt: str) -> str:
+        return self._responses.pop(0) if self._responses else ""

--- a/src/varkiel/gemma_model.py
+++ b/src/varkiel/gemma_model.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+"""Placeholder for the Gemma formalization model."""
+
+from __future__ import annotations
+
+
+def extract_facts(text: str) -> list[str]:
+    """Very naive fact extractor splitting sentences."""
+    return [sent.strip() for sent in text.split('.') if sent.strip()]

--- a/src/varkiel/memory_store.py
+++ b/src/varkiel/memory_store.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+"""In-memory knowledge store."""
+
+from __future__ import annotations
+
+from typing import Dict, Any, Iterable
+
+
+class MemoryStore:
+    """Tiny key-value store with embedding vectors."""
+
+    def __init__(self) -> None:
+        self.data: Dict[str, Any] = {}
+
+    def add(self, key: str, value: Any) -> None:
+        self.data[key] = value
+
+    def get(self, key: str) -> Any:
+        return self.data.get(key)
+
+    def search(self, text: str) -> Iterable[Any]:
+        for k, v in self.data.items():
+            if text.lower() in k.lower():
+                yield v

--- a/src/varkiel/phi2_model.py
+++ b/src/varkiel/phi2_model.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+"""Placeholder for the Phi-2 moderation model."""
+
+from __future__ import annotations
+
+
+def moderate(text: str) -> str:
+    """Return text with simple profanity masking."""
+    return text.replace("badword", "****")

--- a/src/varkiel/wildcore.py
+++ b/src/varkiel/wildcore.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+"""Minimal WildCore anomaly detector."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+class WildCore:
+    """Detect banned phrases in text."""
+
+    def __init__(self, banned: Iterable[str] | None = None) -> None:
+        self._banned = set(banned or [])
+
+    def scan(self, text: str) -> bool:
+        """Return True if *text* contains banned content."""
+        lowered = text.lower()
+        return any(word in lowered for word in self._banned)


### PR DESCRIPTION
## Summary
- create `src/varkiel` package
- add simple ConstraintLattice, WildCore, memory store, drift manager
- provide basic Phi‑2 and Gemma stubs
- include a minimal `VarkielAgent` orchestrator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_b_686c52654930832fab27fe2afd2461a4