### PR TITLE
Add persistence adapter and weighted lattice

### DIFF
--- a/src/varkiel/chain_of_justification.py
+++ b/src/varkiel/chain_of_justification.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+
+@dataclass
+class JustificationStep:
+    node_id: str
+    reason: str
+
+
+@dataclass
+class ChainOfJustification:
+    steps: List[JustificationStep] = field(default_factory=list)
+
+    def add_step(self, node_id: str, reason: str) -> None:
+        self.steps.append(JustificationStep(node_id, reason))
+
+    def to_dict(self) -> Dict[str, List[Dict[str, str]]]:
+        return {"chain": [step.__dict__ for step in self.steps]}
+

--- a/src/varkiel/constraint_compiler.py
+++ b/src/varkiel/constraint_compiler.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import json
+from typing import Iterable, List
+
+
+class ConstraintCompiler:
+    """Generate constraint definitions from text or JSON."""
+
+    @staticmethod
+    def from_text(lines: Iterable[str]) -> List[str]:
+        return [line.strip() for line in lines if line.strip()]
+
+    @staticmethod
+    def from_json(data: str) -> List[str]:
+        obj = json.loads(data)
+        if isinstance(obj, list):
+            return [str(x) for x in obj]
+        return [f"{k}: {v}" for k, v in obj.items()]
+

--- a/src/varkiel/constraint_lattice.py
+++ b/src/varkiel/constraint_lattice.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Iterable
+from typing import Dict, List, Iterable, Tuple
+import hashlib
 import numpy as np
 
 
@@ -19,24 +20,67 @@ class ConstraintNode:
 
 
 class ConstraintLattice:
-    """Basic knowledge store and validator."""
+    """Basic knowledge store and validator with weighted edges."""
 
     def __init__(self) -> None:
         self.nodes: Dict[str, ConstraintNode] = {}
+        self.edges: Dict[str, List[Tuple[str, float]]] = {}
 
-    def add_node(self, node_id: str, content: str, *, source: str = "", parents: Iterable[str] | None = None, embedding: Iterable[float] | None = None) -> None:
+    def _sim(self, a: np.ndarray, b: np.ndarray) -> float:
+        return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-6))
+
+    def _default_embed(self, text: str) -> np.ndarray:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        vec = np.frombuffer(digest[:32], dtype=np.uint8).astype(np.float32)
+        norm = np.linalg.norm(vec)
+        return vec / norm if norm else vec
+
+    def add_node(
+        self,
+        node_id: str,
+        content: str,
+        *,
+        source: str = "",
+        parents: Iterable[str] | None = None,
+        embedding: Iterable[float] | None = None,
+        link_threshold: float = 0.8,
+    ) -> None:
         if embedding is None:
-            embedding = np.zeros(3)
+            embedding = self._default_embed(content)
         parents_list = list(parents) if parents else []
-        self.nodes[node_id] = ConstraintNode(content, np.array(embedding), source, parents_list)
+        node_vec = np.array(embedding, dtype=np.float32)
+        self.nodes[node_id] = ConstraintNode(content, node_vec, source, parents_list)
+        self.edges[node_id] = []
+        # link to existing nodes
+        for other_id, other in self.nodes.items():
+            if other_id == node_id:
+                continue
+            weight = self._sim(node_vec, other.embedding)
+            if weight >= link_threshold:
+                self.edges[node_id].append((other_id, weight))
 
     def get(self, node_id: str) -> ConstraintNode | None:
         return self.nodes.get(node_id)
 
-    def query(self, text: str) -> List[ConstraintNode]:
-        """Return nodes with high embedding similarity to *text* (placeholder)."""
-        # In a real system we would embed text and do nearest-neighbour search.
-        return [n for n in self.nodes.values() if n.content.lower() in text.lower()]
+    def query(self, text: str, *, hops: int = 1, threshold: float = 0.8) -> List[ConstraintNode]:
+        """Return nodes with high embedding similarity to *text* using optional multi-hop."""
+        qvec = np.array(self._default_embed(text))
+        results: List[Tuple[float, ConstraintNode]] = []
+        for nid, node in self.nodes.items():
+            sim = self._sim(qvec, node.embedding)
+            if sim >= threshold:
+                results.append((sim, node))
+        if results or hops <= 0:
+            return [n for _, n in sorted(results, reverse=True)]
+
+        # multi-hop search
+        for nid, edges in self.edges.items():
+            for neigh_id, weight in edges:
+                node = self.nodes[neigh_id]
+                sim = self._sim(qvec, node.embedding) * weight
+                if sim >= threshold * 0.9:
+                    results.append((sim, node))
+        return [n for _, n in sorted(results, reverse=True)]
 
     def validate(self, text: str) -> bool:
         """Check that *text* does not contradict stored constraints (placeholder)."""

--- a/src/varkiel/document_ingestor.py
+++ b/src/varkiel/document_ingestor.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Dict
+
+import PyPDF2
+
+from .constraint_lattice import ConstraintLattice
+
+
+class DocumentIngestor:
+    """Parse documents and register constraints."""
+
+    def __init__(self, lattice: ConstraintLattice) -> None:
+        self.lattice = lattice
+
+    def ingest_pdf(self, path: str | Path, *, source: str) -> None:
+        reader = PyPDF2.PdfReader(str(path))
+        text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        for i, line in enumerate(text.splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            node_id = f"{source}_{i}"
+            self.lattice.add_node(node_id, line, source=source)
+
+    def ingest_json(self, path: str | Path, *, source: str) -> None:
+        data = json.loads(Path(path).read_text())
+        for key, value in data.items():
+            node_id = f"{source}_{key}"
+            self.lattice.add_node(node_id, str(value), source=source)
+

--- a/src/varkiel/memory_store.py
+++ b/src/varkiel/memory_store.py
@@ -4,19 +4,95 @@
 from __future__ import annotations
 
 import hashlib
+import pickle
+import sqlite3
+import zlib
 from collections.abc import Callable, Iterable
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import numpy as np
 
 
-class MemoryStore:
-    """Tiny key-value store with optional embedding search."""
+class MemoryPersistenceAdapter:
+    """Persist ``MemoryStore`` contents to a SQLite database."""
 
-    def __init__(self, embed_fn: Callable[[str], np.ndarray] | None = None) -> None:
+    def __init__(self, db_path: str | Path = "memory.db") -> None:
+        self.db_path = Path(db_path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memory (
+                    key TEXT PRIMARY KEY,
+                    embedding BLOB,
+                    value BLOB,
+                    origin TEXT,
+                    lineage TEXT,
+                    timestamp TEXT
+                )
+                """
+            )
+
+    def save(self, data: dict[str, dict[str, Any]]) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            for key, entry in data.items():
+                emb = entry["embedding"].astype(np.float32).tobytes()
+                value_blob = zlib.compress(pickle.dumps(entry["value"]))
+                meta = entry["metadata"]
+                conn.execute(
+                    "REPLACE INTO memory (key, embedding, value, origin, lineage, timestamp) VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        key,
+                        emb,
+                        value_blob,
+                        meta.get("origin", ""),
+                        meta.get("lineage"),
+                        meta.get("timestamp"),
+                    ),
+                )
+            conn.commit()
+
+    def load(self) -> dict[str, dict[str, Any]]:
+        data: dict[str, dict[str, Any]] = {}
+        if not self.db_path.exists():
+            return data
+        with sqlite3.connect(self.db_path) as conn:
+            for row in conn.execute(
+                "SELECT key, embedding, value, origin, lineage, timestamp FROM memory"
+            ):
+                key = row[0]
+                embedding = np.frombuffer(row[1], dtype=np.float32)
+                value = pickle.loads(zlib.decompress(row[2]))
+                data[key] = {
+                    "value": value,
+                    "embedding": embedding,
+                    "metadata": {
+                        "origin": row[3],
+                        "lineage": row[4],
+                        "timestamp": row[5],
+                    },
+                }
+        return data
+
+
+class MemoryStore:
+    """Tiny key-value store with optional embedding search and persistence."""
+
+    def __init__(
+        self,
+        embed_fn: Callable[[str], np.ndarray] | None = None,
+        *,
+        persistence: MemoryPersistenceAdapter | None = None,
+    ) -> None:
         self.data: dict[str, dict[str, Any]] = {}
         self.embed_fn = embed_fn or self._default_embed
+        self.persistence = persistence
+        if self.persistence is not None:
+            self.data.update(self.persistence.load())
 
     def _default_embed(self, text: str) -> np.ndarray:
         digest = hashlib.sha256(text.encode("utf-8")).digest()
@@ -37,10 +113,17 @@ class MemoryStore:
                 "lineage": lineage,
             },
         }
+        if self.persistence is not None:
+            self.persistence.save({key: self.data[key]})
 
     def get(self, key: str) -> Any:
         entry = self.data.get(key)
         return entry["value"] if entry else None
+
+    def flush(self) -> None:
+        """Persist all stored items to disk."""
+        if self.persistence is not None:
+            self.persistence.save(self.data)
 
     def search(self, text: str) -> Iterable[Any]:
         for k, v in self.data.items():

--- a/tests/unit/test_memory_persistence.py
+++ b/tests/unit/test_memory_persistence.py
@@ -1,0 +1,21 @@
+import numpy as np
+from varkiel.memory_store import MemoryStore, MemoryPersistenceAdapter
+
+
+def simple_embed(text: str) -> np.ndarray:
+    vec = np.zeros(2, dtype=np.float32)
+    vec[0] = text.count("foo")
+    vec[1] = text.count("bar")
+    norm = np.linalg.norm(vec)
+    return vec / norm if norm else vec
+
+
+def test_persistence_roundtrip(tmp_path):
+    db = tmp_path / "mem.db"
+    adapter = MemoryPersistenceAdapter(db)
+    store = MemoryStore(embed_fn=simple_embed, persistence=adapter)
+    store.add("x", "foo bar", origin="unit")
+    store.flush()
+
+    reloaded = MemoryStore(embed_fn=simple_embed, persistence=adapter)
+    assert reloaded.get("x") == "foo bar"

--- a/tests/unit/test_weighted_lattice.py
+++ b/tests/unit/test_weighted_lattice.py
@@ -1,0 +1,13 @@
+import numpy as np
+from varkiel.constraint_lattice import ConstraintLattice
+
+
+def test_linking_and_query():
+    cl = ConstraintLattice()
+    cl.add_node("a", "hello world")
+    cl.add_node("b", "hello there", link_threshold=0.0)
+    results = cl.query("hello world")
+    assert any(node.content == "hello world" for node in results)
+    # ensure edges created
+    assert "b" in [n for n, _ in cl.edges.get("a", [])] or "a" in [n for n, _ in cl.edges.get("b", [])]
+


### PR DESCRIPTION
## Summary
- introduce `MemoryPersistenceAdapter` for saving and loading `MemoryStore` data through SQLite
- allow `MemoryStore` to persist added entries and flush to disk
- extend `ConstraintLattice` with weighted edge linking and multi-hop `query`
- add small utility modules `ConstraintCompiler`, `DocumentIngestor`, and `ChainOfJustification`
- test memory persistence and weighted lattice behaviour

## Testing
- `pytest -q tests/unit/test_memory_store.py tests/unit/test_memory_persistence.py tests/unit/test_weighted_lattice.py`

------
https://chatgpt.com/codex/tasks/task_b_686cb26817d0832f94bc9843bdbbabba