### PR TITLE
Add synthetic cognitive evolution methodology

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Welcome! This page is the starting point for all user guides, design notes, and 
 ## Proposals
 - [Phi-2 Integration Proposal](phi2_integration_proposal.md)
 - [Cognitive Integration Loop](cognitive_integration_loop.md)
+- [Metodologia de Evolução Cognitiva Sintética](synthetic_cognitive_evolution.md)
 
 ## Examples
 - [Transformers Gemma Example](transformers_gemma_example.md)

--- a/docs/synthetic_cognitive_evolution.md
+++ b/docs/synthetic_cognitive_evolution.md
@@ -1,0 +1,20 @@
+# Metodologia para Evolução Cognitiva Sintética
+
+Esta proposta descreve como os módulos do repositório podem ser combinados para orquestrar a cooperação entre múltiplos agentes LLM de forma contínua.
+
+## 1. Negociação de Contexto e Resolução de Conflitos
+Utilize `MultiAgentHarmonizer` para conciliar preferências de diferentes agentes. O harmonizador registra no `HierarchicalMemory` os estados de negociação e permite voto ponderado por meio de `HarmonizationPolicy`.
+
+## 2. Memória Hierárquica Distribuída
+`HierarchicalMemory` mantém o histórico compartilhado de decisões. Cada agente consulta e atualiza estruturas aninhadas, simulando uma memória distribuída persistente entre sessões.
+
+## 3. Arquitetura Tripartite de Controle
+Integre o `StructuralConstraintEngine`, `SymbolicCoherenceEngine` e `PhenomenologicalTracker` sob um controlador central. Essa organização segue o modelo descrito em `varkiel_agent_main/README.md`, garantindo integridade estrutural, coerência simbólica e fidelidade fenomenológica.
+
+## 4. Inferência Distribuída como Cognição
+Conforme discutido em `ARCHITECTURE.md`, pontos de aplicação de restrições funcionam como nós de decisão distribuídos. Cada agente aplica restrições localmente e compartilha resultados via memória, formando um mecanismo coletivo de inferência.
+
+## 5. Métrica de Autonomia e Aprendizado Contínuo
+Acompanhe o grau de autonomia com `EmancipationMetric`. Atualizações periódicas indicam se a cooperação está favorecendo a emancipação cognitiva ou criando dependências indesejadas.
+
+Em conjunto, esses passos compõem um ciclo de evolução sintética em que agentes compartilham memória, negociam preferências e distribuem inferências, mantendo flexibilidade simbólica e coerência estrutural.

--- a/examples/synthetic_evolution_demo.py
+++ b/examples/synthetic_evolution_demo.py
@@ -1,0 +1,40 @@
+"""Demonstration of synthetic cognitive evolution across LLM agents.
+
+This script wires together the lightweight cognitive modules to show how
+agents might negotiate context, share memory and track autonomy.
+"""
+from cognitive_arch.harmonization_policies import (
+    MultiAgentHarmonizer,
+    HarmonizationPolicy,
+)
+from cognitive_arch.hierarchical_memory import HierarchicalMemory
+from cognitive_arch.emancipation_metric import EmancipationMetric
+
+
+class CentralController:
+    """Minimal controller integrating harmonization and autonomy tracking."""
+
+    def __init__(self) -> None:
+        self.memory = HierarchicalMemory()
+        self.harmonizer = MultiAgentHarmonizer(self.memory)
+        self.emancipation = EmancipationMetric(self.memory)
+
+    def register_agent(self, name: str, weight: float = 1.0) -> None:
+        self.harmonizer.register_policy(HarmonizationPolicy(name, weight))
+
+    def decide(self, proposals: dict[str, str]) -> str | None:
+        choice = self.harmonizer.resolve_conflicts(proposals)
+        # simplistic autonomy score: 1 when a decision is made
+        self.emancipation.update(1.0 if choice else 0.0)
+        return choice
+
+
+if __name__ == "__main__":
+    controller = CentralController()
+    controller.register_agent("agent_a", 1.5)
+    controller.register_agent("agent_b", 1.0)
+
+    proposals = {"agent_a": "acao1", "agent_b": "acao2"}
+    decision = controller.decide(proposals)
+    print("Decisao escolhida:", decision)
+    print("Autonomia media:", controller.emancipation.average())


### PR DESCRIPTION
## Summary
- document methodology for synthetic cognitive evolution
- link new document from documentation index
- provide example script wiring harmonizer and autonomy metric

## Testing
- `pytest tests/unit/test_harmonizer.py::test_multi_agent_conflict_resolution -q`

------
https://chatgpt.com/codex/tasks/task_b_686cd8a82058832f86c8a0abe093e0a1