### PR TITLE
Add license map utility and sample UI test

### DIFF
--- a/dashboard/apps/dashboard/package.json
+++ b/dashboard/apps/dashboard/package.json
@@ -24,6 +24,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^14.3.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
@@ -31,9 +33,12 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
+    "husky": "^9.1.7",
+    "jsdom": "^24.1.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
     "vite": "^7.0.2",
-    "vite-tsconfig-paths": "^5.0.0"
+    "vite-tsconfig-paths": "^5.0.0",
+    "vitest": "^1.6.1"
   }
 }

--- a/dashboard/apps/dashboard/src/components/ui/Button.test.tsx
+++ b/dashboard/apps/dashboard/src/components/ui/Button.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Button } from './Button';
+
+
+describe('Button component', () => {
+  it('renders provided children', () => {
+    render(<Button>Click</Button>);
+    expect(screen.getByText('Click')).toBeDefined();
+  });
+
+  it('applies custom className', () => {
+    render(<Button className="custom">Text</Button>);
+    const btn = screen.getByText('Text');
+    expect(btn.className).toContain('custom');
+  });
+
+  it('triggers onClick handler', () => {
+    const handler = vi.fn();
+    render(<Button onClick={handler}>Go</Button>);
+    screen.getByText('Go').click();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/apps/dashboard/src/components/ui/Button.tsx
+++ b/dashboard/apps/dashboard/src/components/ui/Button.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Button: React.FC<ButtonProps> = ({ children, className = '', ...rest }) => (
+  <button
+    className={`px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring ${className}`}
+    {...rest}
+  >
+    {children}
+  </button>
+);
+
+export default Button;

--- a/dashboard/apps/dashboard/vitest.config.ts
+++ b/dashboard/apps/dashboard/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});

--- a/scripts/license_map_gen.py
+++ b/scripts/license_map_gen.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# (c) 2025 ochoaughini. See LICENSE for full terms.
+"""Wrapper script to generate LICENSE_MAP.md.
+
+This script simply delegates to the canonical `src/tools/gen_license_map.py`
+so it can be invoked from the `scripts/` directory or via CI workflows.
+"""
+
+from src.tools.gen_license_map import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple wrapper script `license_map_gen.py`
- add UI `Button` component with associated vitest unit tests
- include vitest config for jsdom environment
- update dashboard dev deps for testing

## Testing
- `npx --yes vitest run`


------
https://chatgpt.com/codex/tasks/task_b_6876c079872c832f838ff4f1de01a7b1